### PR TITLE
Explicitly require `date` before using DateTime class

### DIFF
--- a/lib/sslcheck/certificate.rb
+++ b/lib/sslcheck/certificate.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'openssl'
 
 module SSLCheck

--- a/lib/sslcheck/validators/expiration_date.rb
+++ b/lib/sslcheck/validators/expiration_date.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module SSLCheck
   module Validators
     class ExpirationDate < GenericValidator

--- a/lib/sslcheck/validators/issue_date.rb
+++ b/lib/sslcheck/validators/issue_date.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module SSLCheck
   module Validators
     class IssueDate < GenericValidator


### PR DESCRIPTION
`date` isn't required by default so `DateTime` isn't available after loading a fresh irb console:

``` bash
❯ gem install sslcheck                                                                                                                                  sslcheck/git/explicitly-require-date-for-datetime
Successfully installed sslcheck-0.9.0
Parsing documentation for sslcheck-0.9.0
Installing ri documentation for sslcheck-0.9.0
Done installing documentation for sslcheck after 0 seconds
1 gem installed
❯ irb                                                                                                                                                   sslcheck/git/explicitly-require-date-for-datetime
>> require 'sslcheck'
=> true
>> check = SSLCheck::Check.new
=> #<SSLCheck::Check:0x007fe9cb2d68a8 @client=#<SSLCheck::Client:0x007fe9cb2d6880 @response=#<SSLCheck::Client::Response:0x007fe9cb2d6858 @errors=[]>>, @validator=#<SSLCheck::Validator:0x007fe9cb2d6808 @valid=false, @errors=[], @warnings=[], @common_name=nil, @peer_cert=nil, @ca_bundle=[], @validated=false, @default_validators=[SSLCheck::Validators::CommonName, SSLCheck::Validators::IssueDate, SSLCheck::Validators::ExpirationDate, SSLCheck::Validators::CABundle]>, @errors=[], @checked=false>
>> check.check('github.com')
NameError: uninitialized constant SSLCheck::Certificate::DateTime
        from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sslcheck-0.9.0/lib/sslcheck/certificate.rb:7:in `initialize'
        from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sslcheck-0.9.0/lib/sslcheck/client.rb:23:in `new'
        from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sslcheck-0.9.0/lib/sslcheck/client.rb:23:in `peer_cert'
        from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sslcheck-0.9.0/lib/sslcheck/check.rb:50:in `fetch'
        from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sslcheck-0.9.0/lib/sslcheck/check.rb:12:in `check'
        from (irb):3
        from /usr/local/opt/rbenv/versions/2.1.2/bin/irb:11:in `<main>'
```

This PR adds explicit require statements to files in which `DateTime` is used. I did a little digging and it looks like the `simplecov` gem (or one of its dependencies) automatically loads `date`, which explains why this issue didn't come up during testing.
